### PR TITLE
Fix checkout action version

### DIFF
--- a/.github/workflows/wpcom.yml
+++ b/.github/workflows/wpcom.yml
@@ -10,7 +10,7 @@ jobs:
     name: Publish-Website
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Upload the artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use a stable version of `actions/checkout`
- add newline at end of workflow file

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688147c1b9d4832190300bfcc9c6bd4a